### PR TITLE
Check if vars are defined when rendering files

### DIFF
--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -32,10 +32,10 @@ Available variables are listed below, along with default values defined (see def
 ### Requirements Variable defaults
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|:---:|
-|`ee_bindep`|list|no|The variable list to provide bindep requirements if using variables|
-|`ee_python`|list|no|The variable list to provide python requirements if using variables|
-|`ee_collections`|list|no|The variable list to provide galaxy requirements if using variables, in ansible galaxy list form|
-|`ee_roles`|list|no|The variable list to provide galaxy requirements if using variables, in ansible galaxy list form|
+|`ee_bindep`|list|no|The variable list to provide bindep requirements if using variables||
+|`ee_python`|list|no|The variable list to provide python requirements if using variables||
+|`ee_collections`|list|no|The variable list to provide galaxy requirements if using variables, in ansible galaxy list form||
+|`ee_roles`|list|no|The variable list to provide galaxy requirements if using variables, in ansible galaxy list form||
 
 ### Build Step defaults
 |Variable Name|Default Value|Required|Description|

--- a/roles/ee_builder/tasks/main.yml
+++ b/roles/ee_builder/tasks/main.yml
@@ -35,7 +35,4 @@
     push_args:
       dest: "{{ ee_registry_dest }}"
       sign_by: "{{ ee_sign_by | default(omit) }}"
-    retries: 3
-    delay: 10
-    register: image_push_event
   when: ee_image_push

--- a/roles/ee_builder/tasks/main.yml
+++ b/roles/ee_builder/tasks/main.yml
@@ -35,4 +35,7 @@
     push_args:
       dest: "{{ ee_registry_dest }}"
       sign_by: "{{ ee_sign_by | default(omit) }}"
+    retries: 3
+    delay: 10
+    register: image_push_event
   when: ee_image_push

--- a/roles/ee_builder/templates/bindep.j2
+++ b/roles/ee_builder/templates/bindep.j2
@@ -1,3 +1,5 @@
+{% if ee_bindep is defined %}
 {% for item in ee_bindep %}
 {{ item }}
 {% endfor %}
+{% endif %}

--- a/roles/ee_builder/templates/bindep.j2
+++ b/roles/ee_builder/templates/bindep.j2
@@ -1,5 +1,7 @@
 {% if ee_bindep is defined %}
+{%      if ee_bindep|length %}
 {% for item in ee_bindep %}
 {{ item }}
 {% endfor %}
+{%      endif %}
 {% endif %}

--- a/roles/ee_builder/templates/execution_environment.yml.j2
+++ b/roles/ee_builder/templates/execution_environment.yml.j2
@@ -37,11 +37,8 @@ dependencies:
 
 {% if ee_prepend|length or ee_append|length %}
 additional_build_steps:
-{% if ee_prepend|length %}  prepend: {% else %}{% endif %}
-
-{% for item in ee_prepend %}
-    - {{ item }}
-{% endfor %}
+{% if ee_prepend|length %}  prepend: |{% else %}{% endif %}
+{{ ee_prepend }}
 {% if ee_append|length %}  append: {% else %}{% endif %}
 
 {% for item in ee_append %}

--- a/roles/ee_builder/templates/execution_environment.yml.j2
+++ b/roles/ee_builder/templates/execution_environment.yml.j2
@@ -25,13 +25,19 @@ ansible_config: '{{ ansible_config }}'
         (ee_collections is defined) ) %}
 dependencies:
 {% if ee_bindep is defined %}
+{%      if ee_bindep|length %}
   system: {{ bindep_file }}
+{%      endif %}
 {% endif %}
 {% if ee_python is defined %}
+{%      if ee_python|length %}
   python: {{ python_requirements_file }}
+{%      endif %}
 {% endif %}
 {% if ee_collections is defined %}
+{%      if ee_collections|length %}
   galaxy: {{ galaxy_requirements_file }}
+{%      endif %}
 {% endif %}
 {% endif %}
 

--- a/roles/ee_builder/templates/execution_environment.yml.j2
+++ b/roles/ee_builder/templates/execution_environment.yml.j2
@@ -23,6 +23,9 @@ ansible_config: '{{ ansible_config }}'
 {% if ( (ee_bindep is defined) or
         (ee_python is defined) or
         (ee_collections is defined) ) %}
+{% if ( (ee_bindep|length ) or
+        (ee_python|length ) or
+        (ee_collections|length ) ) %}
 dependencies:
 {% if ee_bindep is defined %}
 {%      if ee_bindep|length %}
@@ -38,6 +41,7 @@ dependencies:
 {%      if ee_collections|length %}
   galaxy: {{ galaxy_requirements_file }}
 {%      endif %}
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/roles/ee_builder/templates/execution_environment.yml.j2
+++ b/roles/ee_builder/templates/execution_environment.yml.j2
@@ -1,6 +1,9 @@
 ---
 version: {{ ee_version }}
 
+{% if ( (galaxy_cli_opts is defined) or
+        (ee_base_image is defined) or
+        (builder_image is defined) ) %}
 build_arg_defaults:
 {% if galaxy_cli_opts is defined %}
   ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: "{{ galaxy_cli_opts }}"
@@ -11,11 +14,15 @@ build_arg_defaults:
 {% if builder_image is defined %}
   EE_BUILDER_IMAGE: {{ builder_image }}
 {% endif %}
+{% endif %}
 
 {% if ansible_config is defined %}
 ansible_config: '{{ ansible_config }}'
 {% endif %}
 
+{% if ( (ee_bindep is defined) or
+        (ee_python is defined) or
+        (ee_collections is defined) ) %}
 dependencies:
 {% if ee_bindep is defined %}
   system: {{ bindep_file }}
@@ -25,6 +32,7 @@ dependencies:
 {% endif %}
 {% if ee_collections is defined %}
   galaxy: {{ galaxy_requirements_file }}
+{% endif %}
 {% endif %}
 
 {% if ee_prepend|length or ee_append|length %}

--- a/roles/ee_builder/templates/execution_environment.yml.j2
+++ b/roles/ee_builder/templates/execution_environment.yml.j2
@@ -38,6 +38,8 @@ dependencies:
 {% if ee_prepend|length or ee_append|length %}
 additional_build_steps:
 {% if ee_prepend|length %}  prepend: {% else %}{% endif %}
+
+{% for item in ee_prepend %}
     - {{ item }}
 {% endfor %}
 {% if ee_append|length %}  append: {% else %}{% endif %}

--- a/roles/ee_builder/templates/execution_environment.yml.j2
+++ b/roles/ee_builder/templates/execution_environment.yml.j2
@@ -37,8 +37,9 @@ dependencies:
 
 {% if ee_prepend|length or ee_append|length %}
 additional_build_steps:
-{% if ee_prepend|length %}  prepend: |{% else %}{% endif %}
-{{ ee_prepend }}
+{% if ee_prepend|length %}  prepend: {% else %}{% endif %}
+    - {{ item }}
+{% endfor %}
 {% if ee_append|length %}  append: {% else %}{% endif %}
 
 {% for item in ee_append %}

--- a/roles/ee_builder/templates/execution_environment.yml.j2
+++ b/roles/ee_builder/templates/execution_environment.yml.j2
@@ -6,13 +6,19 @@ version: {{ ee_version }}
         (builder_image is defined) ) %}
 build_arg_defaults:
 {% if galaxy_cli_opts is defined %}
+{%    if galaxy_cli_opts|length %}
   ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: "{{ galaxy_cli_opts }}"
+{%    endif %}
 {% endif %}
 {% if ee_base_image is defined %}
+{%    if ee_base_image|length %}
   EE_BASE_IMAGE: {{ ee_base_image }}
+{%    endif %}
 {% endif %}
 {% if builder_image is defined %}
+{%    if builder_image|length %}
   EE_BUILDER_IMAGE: {{ builder_image }}
+{%    endif %}
 {% endif %}
 {% endif %}
 

--- a/roles/ee_builder/templates/python_req.j2
+++ b/roles/ee_builder/templates/python_req.j2
@@ -1,3 +1,5 @@
+{% if ee_python is defined %}
 {% for item in ee_python %}
 {{ item }}
 {% endfor %}
+{% endif %}

--- a/roles/ee_builder/templates/python_req.j2
+++ b/roles/ee_builder/templates/python_req.j2
@@ -1,5 +1,7 @@
 {% if ee_python is defined %}
+{%      if ee_python|length %}
 {% for item in ee_python %}
 {{ item }}
 {% endfor %}
+{%      endif %}
 {% endif %}

--- a/roles/ee_builder/templates/requiremets.yml.j2
+++ b/roles/ee_builder/templates/requiremets.yml.j2
@@ -1,20 +1,20 @@
 ---
 {% if ee_roles is defined %}
-{% if ee_roles|length %}roles: {% endif %}
-
+{%    if ee_roles|length %}
+roles: 
 {% for item in ee_roles %}
 - name: {{ item.name }}
   {% if item.version is defined %}version: {{ item.version }}{% endif %}
-
 {% endfor %}
+{%    endif %}
 {% endif %}
 
 {% if ee_collections is defined %}
-{% if ee_collections|length %}collections: {% endif %}
-
+{%    if ee_collections|length %}
+collections: 
 {% for item in ee_collections %}
 - name: {{ item.name }}
   {% if item.version is defined %}version: {{ item.version }}{% endif %}
-
 {% endfor %}
+{%    endif %}
 {% endif %}

--- a/roles/ee_builder/templates/requiremets.yml.j2
+++ b/roles/ee_builder/templates/requiremets.yml.j2
@@ -14,7 +14,7 @@ roles:
 collections: 
 {% for item in ee_collections %}
 - name: {{ item.name }}
-  {% if item.version is defined %}version: {{ item.version }}{% endif %}
+{% if item.version is defined %}version: {{ item.version }}{% endif %}
 {% endfor %}
 {%    endif %}
 {% endif %}


### PR DESCRIPTION
### What does this PR do?
Hi,

I am using the "ee_builder" role, but I do not need to install any kind of Python packages, Ansible collections or system dependencies on the execution environment. For that reason I do not set any of the vars `ee_bindep`, `ee_python`, `ee_collections`, `ee_roles`.

The problem is that if the three variables are not set, first task in the playbook fails.
Also, if `ee_jinja_templates_create` is set to true, it will try to render bindep.txt, python_req.txt and requirements.yml. This is bad, because what if I have defined `ee_python` but not the `ee_bindep`?

I think better possible behaviour is to only render bindep.txt when ee_bindep is defined, same with the other vars.

Any thoughts on this?

Also, there is issue when running the ansible-builder and `ee_bindep`, `ee_python`, `ee_collections`, `ee_roles` are unset.

```
---
version: 1

build_arg_defaults:
  ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: "-v"
  EE_BASE_IMAGE: registry.redhat.io/ansible-automation-platform-21/ee-supported-rhel8:1.0.1-11

dependencies:

additional_build_steps:

  append:
    - RUN microdnf update
    - RUN microdnf reinstall tzdata --nodocs -y
    - RUN microdnf clean all
    - RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime
```
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/38217290/155751734-d2f87c5b-10d8-445c-a217-325f52b02946.png">

In order to fix this little issues, I have created my own fork and tested. Let me know if you think this makes sense. 

Thanks in advance,