### PR TITLE
Fix the ee_builder_base example

### DIFF
--- a/examples/ee_builder_base.yaml
+++ b/examples/ee_builder_base.yaml
@@ -5,14 +5,14 @@
   collections:
     - redhat_cop.ee_utilities
   vars:
-    ee_registry_dest: ahnosso.node
     ee_builder_dir_clean: true
     ah_host: ahnosso.node
-    ee_ah_token: 4ab76668c4b2622ab1dfb7cbee7e6c9b8e62c0f5
+    ah_token: 4ab76668c4b2622ab1dfb7cbee7e6c9b8e62c0f5
+    ee_registry_dest: ahnosso.node
     ee_registry_username: admin
     ee_registry_password: secret123
     ee_list:
-      - name: custom_ee
+      - ee_name: custom_ee
         # base_image
         bindep:
           - python38-requests [platform:centos-8 platform:rhel-8]

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -43,7 +43,7 @@ It takes variables from the following sections the list variables section.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`name`||yes|Name of the ee image to create.|
+|`ee_name`||yes|Name of the ee image to create.|
 |`ee_base_image`|"registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:latest"|no|Build arg specifies the base image for the execution environment to use.|
 |`prepend`|list|no|Ansible Builder Additional commands may be specified in the additional_build_steps section, for execution before the main build steps (prepend).|
 |`append`|list|no|Ansible Builder Additional commands may be specified in the additional_build_steps section, for execution after the main build steps (append).|
@@ -85,7 +85,7 @@ ansible-playbook playbook.yml
     ee_registry_username: admin
     ee_registry_password: secret123
     ee_list:
-      - name: custom_ee
+      - ee_name: custom_ee
         # base_image
         bindep:
           - python38-requests [platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

It fixes one of the example playbook as well as the role documentation.

I had to test the local role rather than the remote role as the [latest 1.0.1](https://github.com/redhat-cop/ee_utilities/releases/tag/1.0.1) tag was pushed in May 27.

### How should this be tested?

I tested this locally pushing to [quay.io/sychen/custom_ee:1.0](https://quay.io/repository/sychen/custom_ee?tab=tags&tag=1.0).

### Is there a relevant Issue open for this?

No.
