### PR TITLE
Added task to clean up ee_controller.yaml once the build completes

### DIFF
--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -96,4 +96,10 @@
     state: absent
     path: "{{ build_dir.path | default(builder_dir) }}"
   when: ee_builder_dir_clean
+
+- name: Remove ee_controller.yaml
+  ansible.builtin.file:
+    state: absent
+    path: /tmp/ee_controller.yaml
+  when: ee_builder_dir_clean
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Added a task that cleans up /tmp/ee_controller.yaml at the end of the ee_builder run, as it creates an issue when 2 different users try to run the role in a playbook, where the 2nd user is unable to access the file and the build therefore fails.

# How should this be tested?

Run the playbook as 1 user, then switch user and run the playbook again. Both EE builds should complete.

# Is there a relevant Issue open for this?

#52

# Other Relevant info, PRs, etc

N/A
