### PR TITLE
Added containers.podman colleciton to galaxy dependencies

### DIFF
--- a/galaxy.yml.j2
+++ b/galaxy.yml.j2
@@ -29,6 +29,6 @@ tags:
     - utils
     - ee_utilities
     - ee_utils
-dependencies: 
+dependencies:
     "containers.podman": ">=1.0.0"
 ...

--- a/galaxy.yml.j2
+++ b/galaxy.yml.j2
@@ -29,5 +29,6 @@ tags:
     - utils
     - ee_utilities
     - ee_utils
-dependencies: {}
+dependencies: 
+    "containers.podman": ">=1.0.0"
 ...

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -96,10 +96,4 @@
     state: absent
     path: "{{ build_dir.path | default(builder_dir) }}"
   when: ee_builder_dir_clean
-
-- name: Remove ee_controller.yaml
-  ansible.builtin.file:
-    state: absent
-    path: /tmp/ee_controller.yaml
-  when: ee_builder_dir_clean
 ...

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -96,4 +96,10 @@
     state: absent
     path: "{{ build_dir.path | default(builder_dir) }}"
   when: ee_builder_dir_clean
+
+- name: Remove ee_controller.yaml
+  ansible.builtin.file:
+    state: absent
+    path: /tmp/ee_controller.yaml
+  when: ee_builder_dir_clean
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fixes issue when running ee_builder, where it would fail when it runs in cases where containers.podman is not installed

# How should this be tested?

Install ee_utilities, which should install ee_utilities and also containers.podman. Then run ee_builder to build an EE. Should complete successfully

# Is there a relevant Issue open for this?

#54 
