### PR TITLE
Fix dir removal issue

### DIFF
--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -84,10 +84,4 @@
       dest: "{{ ee_registry_dest }}"
       sign_by: "{{ ee_sign_by | default(omit) }}"
   when: ee_image_push
-
-- name: Empty build directory
-  ansible.builtin.file:
-    state: absent
-    path: "{{ build_dir.path | default(builder_dir) }}"
-  when: ee_builder_dir_clean
 ...

--- a/roles/ee_builder/tasks/main.yml
+++ b/roles/ee_builder/tasks/main.yml
@@ -5,6 +5,12 @@
   loop_control:
     loop_var: __execution_environment_definition
 
+- name: Empty build directory
+  ansible.builtin.file:
+    state: absent
+    path: "{{ build_dir.path | default(builder_dir) }}"
+  when: ee_builder_dir_clean
+
 - name: Push to controller
   when: ee_create_controller_def
   block:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Move the place where the temporary directory is deleted.
Previously it was being deleted inside the loop, and when the next item was processed:
- the directory had been deleted
- the when condition was preventing the directory to be created again
- further task would fail due to the directory being missing.

# How should this be tested?

Manual
# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

None