### PR TITLE
Add in type & source to collections

### DIFF
--- a/roles/ee_builder/templates/requirements.yml.j2
+++ b/roles/ee_builder/templates/requirements.yml.j2
@@ -11,7 +11,7 @@ collections:
   type: {{ item.type }}
 {% endif %}
 {% if item.source is defined %}
-source: {{ item.source }}
+  source: {{ item.source }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/roles/ee_builder/templates/requirements.yml.j2
+++ b/roles/ee_builder/templates/requirements.yml.j2
@@ -7,6 +7,12 @@ collections:
 {% if item.version is defined %}
   version: {{ item.version }}
 {% endif %}
+{% if item.type is defined %}
+  type: {{ item.type }}
+{% endif %}
+{% if item.source is defined %}
+source: {{ item.source }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Adds in a couple of more types to the template for requirements.yml to allow collections to be source from an internal url (eg .tar.gz file)

# How should this be tested?

Configure a collection to point to a file directly, rather than a galaxy API eg (Mainly used for internal repos like artifactory etc)

```
collections: 
 - name community.general
   type: url
   source: https://galaxy.ansible.com/download/community-general-6.2.0.tar.gz
```

# Is there a relevant Issue open for this?

https://github.com/redhat-cop/ee_utilities/discussions/66

# Other Relevant info, PRs, etc

N/A