### PR TITLE
Define default value of ee_base_registry_username and ee_base_registry_password declared as what has been stated in README.md

### DIFF
--- a/roles/ee_builder/defaults/main.yml
+++ b/roles/ee_builder/defaults/main.yml
@@ -4,12 +4,12 @@ ee_container_runtime: podman
 ee_version: 3
 
 
-ee_stream: "{% if ee_base_registry_username is defined %}downstream{% else %}upstream{% endif %}"
+ee_stream: "{% if ee_registry_username is defined %}downstream{% else %}upstream{% endif %}"
 
 # Image defaults
 ee_base_image: "{{ __ee_stream_images[ee_stream].base_image }}"
-ee_registry_username: "{{ ee_base_registry_username | default(omit, true) }}"
-ee_registry_password: "{{ ee_base_registry_password | default(omit, true) }}"
+ee_base_registry_username: "{{ ee_registry_username | default(omit, true) }}"
+ee_base_registry_password: "{{ ee_registry_password | default(omit, true) }}"
 
 # Req File defaults
 ansible_cfg_file: ansible.cfg

--- a/roles/ee_builder/defaults/main.yml
+++ b/roles/ee_builder/defaults/main.yml
@@ -3,13 +3,12 @@
 ee_container_runtime: podman
 ee_version: 3
 
-
-ee_stream: "{% if ee_registry_username is defined %}downstream{% else %}upstream{% endif %}"
-
 # Image defaults
 ee_base_image: "{{ __ee_stream_images[ee_stream].base_image }}"
 ee_base_registry_username: "{{ ee_registry_username | default(omit, true) }}"
 ee_base_registry_password: "{{ ee_registry_password | default(omit, true) }}"
+
+ee_stream: "{% if ee_base_registry_username is defined %}downstream{% else %}upstream{% endif %}"
 
 # Req File defaults
 ansible_cfg_file: ansible.cfg


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Define default value of ee_base_registry_username and ee_base_registry_password declared in defaults folder reflecting what has been stated in README.md

# Is there a relevant Issue open for this?

https://github.com/redhat-cop/ee_utilities/issues/133
