### PR TITLE
Fixed an issue where a tempfile was not created locally

### DIFF
--- a/changelogs/fragments/148-delegation.yml
+++ b/changelogs/fragments/148-delegation.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed an issue where a tempfile was not created locally, but rather on the remote machine
+...

--- a/roles/ee_builder/tasks/main.yml
+++ b/roles/ee_builder/tasks/main.yml
@@ -7,6 +7,7 @@
 
 - name: Push to controller
   when: ee_create_controller_def
+  delegate_to: localhost
   block:
     - name: Create temporary folder
       ansible.builtin.tempfile:
@@ -19,12 +20,10 @@
         src: ee_controller.yaml.j2
         dest: "{{ controller_ee.path }}/ee_controller.yaml"
         mode: '0644'
-      delegate_to: localhost
 
     - name: Include templated variable
       ansible.builtin.include_vars:
         file: "{{ controller_ee.path }}/ee_controller.yaml"
-      delegate_to: localhost
 
     - name: Display templated variables
       ansible.builtin.debug:


### PR DESCRIPTION

# What does this PR do?
Fixes issue where the ee_builder role running on a remote machine will fail because certain sections were delegated to localhost but others were not. This unifies the section to run only on localhost

# How should this be tested?
See issue

# Is there a relevant Issue open for this?
resolves #148 

# Other Relevant info, PRs, etc
N/A