### PR TITLE
Remove redundant path

### DIFF
--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -42,7 +42,7 @@
 - name: Run the Ansible Builder Program
   ansible.builtin.command: >
     ansible-builder build -f
-      {{ ee_builder_dir | default(build_dir.path) }}/execution_environment.yml
+      execution_environment.yml
       -t {{ __execution_environment_definition.name | default( __execution_environment_definition.ee_name )}}{% if __execution_environment_definition.tag is defined %}:{{ __execution_environment_definition.tag }}{% endif %} --container-runtime={{ ee_container_runtime }}
       {% if ee_prune_images %} --prune-images{% endif %}
       {% if ee_galaxy_keyring is defined %} --galaxy-keyring={{ ee_galaxy_keyring }}{% endif %}


### PR DESCRIPTION
# What does this PR do?

Currently the definition of the path is redundant. If ee_builder_dir is specified we both chdir into and try that absolute path, which can't work.

The idea here is to chdir into it and looking for local execution_environment.yml

# How should this be tested?

Specify `ee_builder_dir`

# Is there a relevant Issue open for this?

N/A

# Other Relevant info, PRs, etc

N/A
