### PR TITLE
Allow to skip the generation of EE definition

### DIFF
--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -81,7 +81,7 @@ It takes variables from the following sections the list variables section.
 |`build_files`|dict|no|This section allows you to add any file to the build context directory. Reference [builder build_files documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#additional-build-files), examples and our examples for its structure.|
 |`images`|dict|no|This section is a dictionary that is used to define the base image to be used. Reference [builder images documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#images), examples and our examples for its structure. This will override 'ee_base_image'.|
 |`options`|dict|no|This section is a dictionary that contains keywords/options that can affect builder runtime functionality. Reference [builder options documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#options), examples and our examples for its structure.|
-|`skip_generation`|bool|false|Should the generation of execution_environment.yml be skipped and an already provided definition be built.|
+|`skip_generation`|bool|false|Should the generation of execution_environment.yml be skipped and an already provided definition be used.|
 
 #### Additional List variables for Execution environment definition for Controller configuration
 

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -81,6 +81,7 @@ It takes variables from the following sections the list variables section.
 |`build_files`|dict|no|This section allows you to add any file to the build context directory. Reference [builder build_files documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#additional-build-files), examples and our examples for its structure.|
 |`images`|dict|no|This section is a dictionary that is used to define the base image to be used. Reference [builder images documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#images), examples and our examples for its structure. This will override 'ee_base_image'.|
 |`options`|dict|no|This section is a dictionary that contains keywords/options that can affect builder runtime functionality. Reference [builder options documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#options), examples and our examples for its structure.|
+|`skip_generation`|bool|false|Should the generation of execution_environment.yml be skipped and an already provided definition be built.|
 
 #### Additional List variables for Execution environment definition for Controller configuration
 

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -38,6 +38,7 @@
     src: execution_environment.yml.j2
     dest: "{{ ee_builder_dir | default(build_dir.path) }}/execution_environment.yml"
     mode: '0644'
+  when: not __execution_environment_definition.skip_generation | default(false) | bool
 
 - name: Run the Ansible Builder Program
   ansible.builtin.command: >


### PR DESCRIPTION
# What does this PR do?

Allow a user to skip the generation of EE definition and provide a definition before hand for this role to call builder.

# How should this be tested?

Specifing `skip_generation` to an item of `ee_list`

# Is there a relevant Issue open for this?

N/A

# Other Relevant info, PRs, etc

N/A