### PR TITLE
Explicitly add EE name and tag to destination

### DIFF
--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -79,3 +79,4 @@
     state: absent
     path: "{{ build_dir.path | default(ee_builder_dir) }}"
   when: ee_builder_dir_clean
+...

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -70,7 +70,7 @@
     tag: "{{ __execution_environment_definition.tag | default(omit) }}"
     validate_certs: "{{ ee_validate_certs | default(omit) }}"
     push_args:
-      dest: "{{ ee_registry_dest }}/{{ __execution_environment_definition.name }}{{ ':' + __execution_environment_definition.tag if __execution_environment_definition.tag else '' }}"
+      dest: "{{ ee_registry_dest }}/{{ __execution_environment_definition.name }}{{ (':' + __execution_environment_definition.tag) if __execution_environment_definition.tag is defined }}"
       sign_by: "{{ ee_sign_by | default(omit) }}"
   when: ee_image_push
 

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -70,7 +70,7 @@
     tag: "{{ __execution_environment_definition.tag | default(omit) }}"
     validate_certs: "{{ ee_validate_certs | default(omit) }}"
     push_args:
-      dest: "{{ ee_registry_dest }}"
+      dest: "{{ ee_registry_dest }}/{{ __execution_environment_definition.name }}{{ ':' + __execution_environment_definition.tag if __execution_environment_definition.tag else '' }}"
       sign_by: "{{ ee_sign_by | default(omit) }}"
   when: ee_image_push
 
@@ -79,4 +79,3 @@
     state: absent
     path: "{{ build_dir.path | default(ee_builder_dir) }}"
   when: ee_builder_dir_clean
-...


### PR DESCRIPTION
This avoids changes in containers.podman behavior where the image name is not always automatically appended. In particular, if you happen to have a port specification it will not automatically append the image name, see https://github.com/containers/ansible-podman-collections/blob/master/plugins/modules/podman_image.py#L792. 

<!--- markdownlint-disable MD041 -->
# What does this PR do?

Instead of relying on automatic appending of the EE name by the podman module, be explicit and append it to the `ee_registry_dest` variable, and if tag is defined, assume that it should also be pushed to the registry with the same tag.

# How should this be tested?

Build any existing execution environment. There should be no change in behaviour - the image should still be pushed. The actual image push is easy to see when running with `-vvv`:

```
    "podman_actions": [
        "/usr/bin/podman image ls my_image:my_tag --format json",
        "/usr/bin/podman inspect my_image:my_tag --format json",
        "/usr/bin/podman push --tls-verify=false --creds username:**** my_image:my_tag some.registry:7001/org/namespace/my_image:my_tag",
        "/usr/bin/podman inspect my_image:my_tag --format json"
    ],
```

# Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
resolves #[number]

# Other Relevant info, PRs, etc

Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
