### PR TITLE
189 - Fixes URL and token concatenation

### DIFF
--- a/changelogs/fragments/189-token-concat.yml
+++ b/changelogs/fragments/189-token-concat.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixes issue where ee_builder role concatenates the URL and token on ansible.cfg
+...

--- a/roles/ee_builder/templates/ansible.cfg.j2
+++ b/roles/ee_builder/templates/ansible.cfg.j2
@@ -3,17 +3,17 @@ server_list = automation_hub_pub,automation_hub_cert,automation_hub_validated,au
 ignore_certs = true
 
 [galaxy_server.automation_hub_cert]
-url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/rh-certified/{% else %}/api/galaxy/content/rh-certified/{% endif %}
+url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/rh-certified/{% else %}/api/galaxy/content/rh-certified/{% endif +%}
 token={{ ee_ah_token }}
 
 [galaxy_server.automation_hub_pub]
-url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/published/{% else %}/api/galaxy/content/published/{% endif %}
+url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/published/{% else %}/api/galaxy/content/published/{% endif +%}
 token={{ ee_ah_token }}
 
 [galaxy_server.automation_hub_comm]
-url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/community/{% else %}/api/galaxy/content/community/{% endif %}
+url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/community/{% else %}/api/galaxy/content/community/{% endif +%}
 token={{ ee_ah_token }}
 
 [galaxy_server.automation_hub_validated]
-url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/validated/{% else %}/api/galaxy/content/validated/{% endif %}
+url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/validated/{% else %}/api/galaxy/content/validated/{% endif +%}
 token={{ ee_ah_token }}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

As per #189 this fixes an issue where the token and URL are concatenated in the generated ansible.cfg

# How should this be tested?

The following tests the output of that specific template in isolation:

`ansible -m template -a "src=roles/ee_builder/templates/ansible.cfg.j2 dest=ansible.cfg mode=0644" localhost -e aap_hostname=gateway.aap25.local -e aap_token=aabbccddee -e @roles/ee_builder/defaults/main.yml`

# Is there a relevant Issue open for this?

resolves #189 

# Other Relevant info, PRs, etc
No
