### PR TITLE
fix linebreak between token and endif jinja

### DIFF
--- a/roles/ee_builder/templates/ansible.cfg.j2
+++ b/roles/ee_builder/templates/ansible.cfg.j2
@@ -4,16 +4,20 @@ ignore_certs = true
 
 [galaxy_server.automation_hub_cert]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/rh-certified/{% else %}/api/galaxy/content/rh-certified/{% endif %}
+
 token={{ ee_ah_token }}
 
 [galaxy_server.automation_hub_pub]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/published/{% else %}/api/galaxy/content/published/{% endif %}
+
 token={{ ee_ah_token }}
 
 [galaxy_server.automation_hub_comm]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/community/{% else %}/api/galaxy/content/community/{% endif %}
+
 token={{ ee_ah_token }}
 
 [galaxy_server.automation_hub_validated]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/validated/{% else %}/api/galaxy/content/validated/{% endif %}
+
 token={{ ee_ah_token }}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fixing linebreak between jinja endif and token

