### PR TITLE
Allow ee_ah_token to be blank for anonymous access

### DIFF
--- a/changelogs/fragments/empty_token.yml
+++ b/changelogs/fragments/empty_token.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Allow ee_ah_token to be blank for anonymous access
+...

--- a/roles/ee_builder/templates/ansible.cfg.j2
+++ b/roles/ee_builder/templates/ansible.cfg.j2
@@ -4,16 +4,16 @@ ignore_certs = true
 
 [galaxy_server.automation_hub_cert]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/rh-certified/{% else %}/api/galaxy/content/rh-certified/{% endif +%}
-token={{ ee_ah_token }}
+{% if ee_ah_token %}token={{ ee_ah_token }}{% endif %}
 
 [galaxy_server.automation_hub_pub]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/published/{% else %}/api/galaxy/content/published/{% endif +%}
-token={{ ee_ah_token }}
+{% if ee_ah_token %}token={{ ee_ah_token }}{% endif %}
 
 [galaxy_server.automation_hub_comm]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/community/{% else %}/api/galaxy/content/community/{% endif +%}
-token={{ ee_ah_token }}
+{% if ee_ah_token %}token={{ ee_ah_token }}{% endif %}
 
 [galaxy_server.automation_hub_validated]
 url=https://{{ ee_ah_host }}{% if ee_aap_version >= 2.5 %}/pulp_ansible/galaxy/validated/{% else %}/api/galaxy/content/validated/{% endif +%}
-token={{ ee_ah_token }}
+{% if ee_ah_token %}token={{ ee_ah_token }}{% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fix issue where we want to stop the token being added to the listing (e.g. when we need anonymous access)

# How should this be tested?

manual. Seeing `ee_ah_token`

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc


