### PR TITLE
Add markdown link checker fix

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,5 @@
+---
+# Define glob expressions to ignore
+ignores:
+  - ".github/**"
+...

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,0 +1,11 @@
+{
+    "httpHeaders": [
+      {
+        "urls": ["https://github.com/", "https://guides.github.com/", "https://help.github.com/", "https://docs.github.com/", "https://developers.redhat.com"],
+        "retryOn429": true,
+        "headers": {
+          "Accept-Encoding": "zstd, br, gzip, deflate"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fixes markdown link checker problem
Also fixing the markdown lint .github stuff which cases the release to fail now. Not sure why this wasn't picked up in these checks

# How should this be tested?
CI