### PR TITLE
Handle build dirs correctly in all cases

### DIFF
--- a/changelogs/fragments/fix_build_dir.yml
+++ b/changelogs/fragments/fix_build_dir.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - make ee_builder_dir work with multiple EEs defined in ee_list
+...

--- a/roles/ee_builder/defaults/main.yml
+++ b/roles/ee_builder/defaults/main.yml
@@ -23,7 +23,6 @@ ee_build_arg_defaults:
 # Controls
 ee_image_push: true
 ee_update_base_images: true
-# mark as breaking change
 ee_pull_collections_from_hub: true
 ee_builder_dir_clean: true
 ee_validate_certs: false

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -1,6 +1,13 @@
 ---
 # tasks file for ee_builder
-- name: Create temporary folder
+- name: Create user-defined build directory
+  ansible.builtin.file:
+    state: directory
+    path: "{{ ee_builder_dir }}"
+    mode: '0700'
+  when: ee_builder_dir is defined
+
+- name: Create temp-named build directory
   ansible.builtin.tempfile:
     state: directory
     suffix: temp
@@ -16,7 +23,7 @@
     force: true
   when: ee_update_base_images
 
-- name: Copy files/folders to pull from for additional_build_files
+- name: Copy files/directories to pull from for additional_build_files
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: "{{ ee_builder_dir | default(build_dir.path) }}/{{ item }}"

--- a/roles/ee_builder/tasks/main.yml
+++ b/roles/ee_builder/tasks/main.yml
@@ -9,7 +9,7 @@
   when: ee_create_controller_def
   delegate_to: localhost
   block:
-    - name: Create temporary folder
+    - name: Create temporary directory
       ansible.builtin.tempfile:
         state: directory
         suffix: temp


### PR DESCRIPTION
Consistently refer to directories as directories while at it.

Also remove an ancient todo-item in defaults/main.yml.

Resolved: #212