### PR TITLE
Feat/enabling multi tag push 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,8 @@ Redhat\_Cop.Ee\_Utilities Release Notes
 
 .. contents:: Topics
 
-v4.0.5
-======
-
-Minor Changes
--------------
-
-- Added support for building and pushing EE images with multiple tags.
-
 v4.0.4
+
 ======
 
 Bugfixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,15 @@ Redhat\_Cop.Ee\_Utilities Release Notes
 
 .. contents:: Topics
 
-v4.0.4
+v4.0.5
+======
 
+Minor Changes
+-------------
+
+- Added support for building and pushing EE images with multiple tags.
+
+v4.0.4
 ======
 
 Bugfixes

--- a/changelogs/fragments/multi-tags.yml
+++ b/changelogs/fragments/multi-tags.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Added support for building and pushing EE images with multiple tags.

--- a/changelogs/fragments/multi-tags.yml
+++ b/changelogs/fragments/multi-tags.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-- Added support for building and pushing EE images with multiple tags.
+  - Added support for building and pushing EE images with multiple tags.
+...

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -76,7 +76,8 @@ It takes variables from the following sections the list variables section.
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
 |`name`||yes|Name of the ee image to create. Only the name goes here, the namespace goes in the ee_registry_dest variable|
-|`tag`||no|Tag to use when pushing the image.|
+|`tag`||no|[DEPRECATED] Tag to use when pushing the image.|
+|`tags`||no|A list of tags to use when pushing the image.|
 |`dependencies`|dict|no|This section allows you to describe any dependencies that will need to be installed into the final image. Reference [builder dependencies documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#dependencies), examples and our examples for its structure.|
 |`build_steps`|dict|no|This section enables you to specify custom build commands for any build phase. Reference [builder build_steps documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#additional-build-steps), examples and our examples for its structure.|
 |`build_items`|list|no|This is a list of files or folders that will be copied to the working directory for use with the build files. Example below.|
@@ -143,7 +144,8 @@ ansible-playbook playbook.yml
     ee_list:
       - name: custom_ee
         alt_name: Custom EE
-        tag: 1-11-21-2
+        tags: 
+          - 1-11-21-2
         dependencies:
           system:
           - python-requests

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -144,7 +144,7 @@ ansible-playbook playbook.yml
     ee_list:
       - name: custom_ee
         alt_name: Custom EE
-        tags: 
+        tags:
           - 1-11-21-2
         dependencies:
           system:

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -7,7 +7,6 @@
   register: build_dir
   when: ee_builder_dir is not defined
 
-
 - name: Pull builder images
   containers.podman.podman_image:
     name: "{{ __execution_environment_definition.images.base_image.name | default(__execution_environment_definition.images.base_image) | default(__execution_environment_definition.base_image) | default(ee_base_image) }}"
@@ -71,7 +70,7 @@
   args:
     chdir: "{{ ee_builder_dir | default(build_dir.path) }}/"
   changed_when: true # these will always run and will always report "changed" otherwise
-  
+
 - name: Push image to registry
   containers.podman.podman_image:
     name: "{{ __execution_environment_definition.name }}"
@@ -96,7 +95,6 @@
   loop_control:
     loop_var: __execution_environment_tag
   when: ee_image_push
-
 
 - name: Empty build directory
   ansible.builtin.file:

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -87,9 +87,9 @@
     executable: "{{ ee_executable | default(omit, true) }}"
     ca_cert_dir: "{{ ee_ca_cert_dir | default(omit) }}"
     validate_certs: "{{ ee_validate_certs | default(omit) }}"
-    tag: "{{ item }}"
+    tag: "{{ __execution_environment_tag }}"
     push_args:
-      dest: "{{ ee_registry_dest }}/{{ __execution_environment_definition.name }}:{{ item }}"
+      dest: "{{ ee_registry_dest }}/{{ __execution_environment_definition.name }}:{{ __execution_environment_tag }}"
       sign_by: "{{ ee_sign_by | default(omit) }}"
   loop: >-
     {{
@@ -97,6 +97,8 @@
        if (__execution_environment_definition.tags is defined and __execution_environment_definition.tags is terable)
        else [__execution_environment_definition.tag | default('latest')])
     }}
+  loop_control:
+    loop_var: __execution_environment_tag
   when: ee_image_push
 
 

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -6,6 +6,12 @@
     suffix: temp
   register: build_dir
   when: ee_builder_dir is not defined
+# Don't break if tag exist, transform it into a list 
+- name: transform ee tag into a list
+  ansible.builtin.set_fact:
+    __execution_environment_definition: "{{  __execution_environment_definition | combine( {tags: [__execution_environment_definition.tag]} ) }}""
+  when: 
+    - __execution_environment_definition.tag is defined
 
 - name: Pull builder images
   containers.podman.podman_image:
@@ -42,17 +48,30 @@
 
 - name: Run the Ansible Builder Program
   ansible.builtin.command: >
-    ansible-builder build -f
-      execution-environment.yaml
-      -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}{% if __execution_environment_definition.tag is defined
-    %}:{{ __execution_environment_definition.tag }}{% endif %} --container-runtime={{ ee_container_runtime }}
-      {% if ee_prune_images %} --prune-images{% endif %}
-      {% if ee_galaxy_keyring is defined %} --galaxy-keyring={{ ee_galaxy_keyring }}{% endif %}
-      {% if ee_galaxy_ignore_signature_status_code is defined %}{% for status_code in ee_galaxy_ignore_signature_status_code %} --galaxy-ignore-signature-status-code={{
-    status_code }}{% endfor %}{% endif %}
-      {% if galaxy_required_valid_signature_count is defined %} --galaxy-required-valid-signature-count={{ galaxy_required_valid_signature_count }}{% endif %}
-      {% if ee_container_policy is defined %} --container-policy={{ ee_container_policy }}{% endif %}
-      --verbosity {{ ee_verbosity | default(0) }}
+    ansible-builder build -f execution-environment.yaml
+    {% if __execution_environment_definition.tags is defined %}
+      {% for tag in __execution_environment_definition.tags %}
+        -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}:{{ tag }}
+      {% endfor %}
+    {% else %}
+      -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}
+    {% endif %}
+    --container-runtime={{ ee_container_runtime }}
+    {% if ee_prune_images %} --prune-images{% endif %}
+    {% if ee_galaxy_keyring is defined %} --galaxy-keyring={{ ee_galaxy_keyring }}{% endif %}
+    {% if ee_galaxy_ignore_signature_status_code is defined %}
+      {% for status_code in ee_galaxy_ignore_signature_status_code %}
+        --galaxy-ignore-signature-status-code={{ status_code }}
+      {% endfor %}
+    {% endif %}
+    {% if galaxy_required_valid_signature_count is defined %}
+      --galaxy-required-valid-signature-count={{ galaxy_required_valid_signature_count }}
+    {% endif %}
+    {% if ee_container_policy is defined %}
+      --container-policy={{ ee_container_policy }}
+    {% endif %}
+    --verbosity {{ ee_verbosity | default(0) }}
+
   args:
     chdir: "{{ ee_builder_dir | default(build_dir.path) }}/"
   changed_when: true # these will always run and will always report "changed" otherwise
@@ -67,12 +86,19 @@
     auth_file: "{{ ee_auth_file | default(omit, true) }}"
     executable: "{{ ee_executable | default(omit, true) }}"
     ca_cert_dir: "{{ ee_ca_cert_dir | default(omit) }}"
-    tag: "{{ __execution_environment_definition.tag | default(omit) }}"
     validate_certs: "{{ ee_validate_certs | default(omit) }}"
+    tag: "{{ item }}"
     push_args:
-      dest: "{{ ee_registry_dest }}/{{ __execution_environment_definition.name }}{{ (':' + __execution_environment_definition.tag) if __execution_environment_definition.tag is defined }}"
+      dest: "{{ ee_registry_dest }}/{{ __execution_environment_definition.name }}:{{ item }}"
       sign_by: "{{ ee_sign_by | default(omit) }}"
+  loop: >-
+    {{
+      (__execution_environment_definition.tags
+       if (__execution_environment_definition.tags is defined and __execution_environment_definition.tags is terable)
+       else [__execution_environment_definition.tag | default('latest')])
+    }}
   when: ee_image_push
+
 
 - name: Empty build directory
   ansible.builtin.file:

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -47,14 +47,18 @@
       {% for tag in __execution_environment_definition.tags %}
         -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}:{{ tag }}
       {% endfor %}
-    {% elif __execution_environment_definition.tag is defined  %}
-        -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}:{{ __execution_environment_definition.tag }}
+    {% elif __execution_environment_definition.tag is defined %}
+      -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}:{{ __execution_environment_definition.tag }}
     {% else %}
       -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}
     {% endif %}
     --container-runtime={{ ee_container_runtime }}
-    {% if ee_prune_images %} --prune-images{% endif %}
-    {% if ee_galaxy_keyring is defined %} --galaxy-keyring={{ ee_galaxy_keyring }}{% endif %}
+    {% if ee_prune_images %}
+      --prune-images
+    {% endif %}
+    {% if ee_galaxy_keyring is defined %}
+      --galaxy-keyring={{ ee_galaxy_keyring }}
+    {% endif %}
     {% if ee_galaxy_ignore_signature_status_code is defined %}
       {% for status_code in ee_galaxy_ignore_signature_status_code %}
         --galaxy-ignore-signature-status-code={{ status_code }}
@@ -69,7 +73,7 @@
     --verbosity {{ ee_verbosity | default(0) }}
   args:
     chdir: "{{ ee_builder_dir | default(build_dir.path) }}/"
-  changed_when: true # these will always run and will always report "changed" otherwise
+  changed_when: true  # these will always run and will always report "changed" otherwise
 
 - name: Push image to registry
   containers.podman.podman_image:

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -6,12 +6,7 @@
     suffix: temp
   register: build_dir
   when: ee_builder_dir is not defined
-# Don't break if tag exist, transform it into a list 
-- name: transform ee tag into a list
-  ansible.builtin.set_fact:
-    __execution_environment_definition: "{{  __execution_environment_definition | combine( {tags: [__execution_environment_definition.tag]} ) }}""
-  when: 
-    - __execution_environment_definition.tag is defined
+
 
 - name: Pull builder images
   containers.podman.podman_image:
@@ -53,6 +48,8 @@
       {% for tag in __execution_environment_definition.tags %}
         -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}:{{ tag }}
       {% endfor %}
+    {% elif __execution_environment_definition.tag is defined  %}
+        -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}:{{ __execution_environment_definition.tag }}
     {% else %}
       -t {{ __execution_environment_definition.name | default(__execution_environment_definition.ee_name) }}
     {% endif %}
@@ -71,11 +68,10 @@
       --container-policy={{ ee_container_policy }}
     {% endif %}
     --verbosity {{ ee_verbosity | default(0) }}
-
   args:
     chdir: "{{ ee_builder_dir | default(build_dir.path) }}/"
   changed_when: true # these will always run and will always report "changed" otherwise
-
+  
 - name: Push image to registry
   containers.podman.podman_image:
     name: "{{ __execution_environment_definition.name }}"
@@ -94,7 +90,7 @@
   loop: >-
     {{
       (__execution_environment_definition.tags
-       if (__execution_environment_definition.tags is defined and __execution_environment_definition.tags is terable)
+       if (__execution_environment_definition.tags is defined and __execution_environment_definition.tags is iterable)
        else [__execution_environment_definition.tag | default('latest')])
     }}
   loop_control:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This PR adds support for building and pushing container images with **multiple tags**.  

Previously, `tag` accepted only a single value. Now, `tags` can be defined as a list, and the logic will build images for each tag in the list and push them to the registry.  

Key points:  
- `tag` remains supported for backward compatibility. Existing definitions will continue to work as before.  
- If both `tag` and `tags` are defined, `tags` takes precedence and `tag` will be ignored.  
- If neither `tag` nor `tags` are defined, the image will default to `latest`.  

# How should this be tested?

Define a new EE in the `ee_list` variable with a list of `tags`, then run a build to verify that images are correctly created and pushed for all specified tags.  

# Is there a relevant Issue open for this?

resolves #204