### PR TITLE
Adding microdnf as pkg manager in example playbook

### DIFF
--- a/examples/ee_builder_base.yaml
+++ b/examples/ee_builder_base.yaml
@@ -42,7 +42,7 @@
           append_final:
             - RUN echo This is a post-install command!
         options:
-           package_manager_path: /usr/bin/microdnf
+          package_manager_path: /usr/bin/microdnf
         images:
           base_image:
             name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9:latest

--- a/examples/ee_builder_base.yaml
+++ b/examples/ee_builder_base.yaml
@@ -41,6 +41,8 @@
             - RUN cat /etc/os-release
           append_final:
             - RUN echo This is a post-install command!
+        options:
+           package_manager_path: /usr/bin/microdnf
         images:
           base_image:
             name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9:latest


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
The current playbook example fails with the following error: 
```
....
/output/scripts/assemble: line 163: /usr/bin/dnf: No such file or directory", "Error: building at STEP \"RUN /output/scripts/assemble\": while running runtime: exit status 127", "", "", "An error occurred (rc=127), see output line(s) above for details."]} 
....
```
This PR fixes this issue by setting the packagemanager to be microdnf instead of dnf

# How should this be tested?
`ansible-playbook examples/ee_builder_base.yaml`

# Is there a relevant Issue open for this?
N/A


