### PR TITLE
Fix/handling empty build steps

### DIFF
--- a/changelogs/fragments/handle_empty_build_steps.yml
+++ b/changelogs/fragments/handle_empty_build_steps.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Handle empty build steps in execution-environment.yaml generation
+...

--- a/roles/ee_builder/defaults/main.yml
+++ b/roles/ee_builder/defaults/main.yml
@@ -36,7 +36,7 @@ ee_create_controller_def: false
 # ee_registry_dest
 
 # Hub host variables for ansible.cfgw
-ee_ah_host: "{{ ah_host | default(aap_hostname)}}"
-ee_ah_token: "{{ ah_token | default(aap_token)}}"
+ee_ah_host: "{{ ah_host | default(aap_hostname) }}"
+ee_ah_token: "{{ ah_token | default(aap_token)  }}"
 ee_aap_version: 2.4
 ...

--- a/roles/ee_builder/defaults/main.yml
+++ b/roles/ee_builder/defaults/main.yml
@@ -37,6 +37,6 @@ ee_create_controller_def: false
 
 # Hub host variables for ansible.cfgw
 ee_ah_host: "{{ ah_host | default(aap_hostname) }}"
-ee_ah_token: "{{ ah_token | default(aap_token)  }}"
+ee_ah_token: "{{ ah_token | default(aap_token) }}"
 ee_aap_version: 2.4
 ...

--- a/roles/ee_builder/templates/execution-environment.yaml.j2
+++ b/roles/ee_builder/templates/execution-environment.yaml.j2
@@ -29,18 +29,24 @@ additional_build_files:
 {% endif -%}
 {% endif -%}
 
-{% if (__execution_environment_definition.build_steps is defined and __execution_environment_definition.build_steps|length )  or
+{% if (__execution_environment_definition.build_steps is defined and __execution_environment_definition.build_steps|length and __execution_environment_definition.build_steps.values() | select('truthy') | list | length > 0 )  or
         (ee_pull_collections_from_hub) %}
 additional_build_steps:
-{% if ee_pull_collections_from_hub and (__execution_environment_definition.build_steps is not defined or (__execution_environment_definition.build_steps is defined and 'prepend_galaxy' not in __execution_environment_definition.build_steps)) %}
+{% if ee_pull_collections_from_hub and 
+      (__execution_environment_definition.build_steps is not defined 
+       or ('prepend_galaxy' not in __execution_environment_definition.build_steps) 
+       or (__execution_environment_definition.build_steps.prepend_galaxy is not defined) 
+       or not __execution_environment_definition.build_steps.prepend_galaxy) %}
   prepend_galaxy:
     - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
 {% endif %}
 {% if __execution_environment_definition.build_steps is defined %}
 {% for key,value in __execution_environment_definition.build_steps.items() %}
+{% if value | list | length > 0 %}
 {{ key | indent(2, true) }}:
 {{ value | to_nice_yaml | indent(4, true) }}
-{%- if key == "prepend_galaxy" and ee_pull_collections_from_hub and 'prepend_galaxy' in __execution_environment_definition.build_steps %}
+{%- endif -%}
+{%- if key == "prepend_galaxy" and ee_pull_collections_from_hub and 'prepend_galaxy' in __execution_environment_definition.build_steps and value | length > 0 %}
     - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This PR updates the Jinja2 template for execution environment (EE) definitions to improve handling of build_steps. 

- `additional_build_steps` section now only appears if there is at least one non-empty step or if ee_pull_collections_from_hub is enabled.
- prepend_galaxy logic updated to safely append ansible.cfg only when necessary.
- All empty build_steps lists are ignored to produce cleaner YAML output.

the bug is : If `prepend_galaxy` is defined but empty ([]) and `ee_pull_collections_from_hub` is defined, the generated YAML is generated : 

```
prepend_galaxy:
[]
    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
```

# How should this be tested?
Run the role with empty build_steps values.
Example:
```
---
ee_list:
  - name: example-image
    alt_name: Custom EE image
    base_image: "registry.example.com/ee:latest"
    tags:
      - latest
    dependencies:
      system: []
      python: []
      galaxy: []
    build_items: []
    build_files: []
    build_steps:
      prepend_base: []
      append_base:  []
      prepend_galaxy: []
      prepend_builder: []
      append_builder: []
      prepend_final: []
      append_final: []
```

