### PR TITLE
Use compact loop labels

### DIFF
--- a/changelogs/fragments/tweak_loop_label.yml
+++ b/changelogs/fragments/tweak_loop_label.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - use compact loop labels when building, don't print the full EE definition
+...

--- a/roles/ee_builder/tasks/main.yml
+++ b/roles/ee_builder/tasks/main.yml
@@ -4,6 +4,7 @@
   loop: "{{ ee_list }}"
   loop_control:
     loop_var: __execution_environment_definition
+    label: "{{ __execution_environment_definition.name }}"
 
 - name: Push to controller
   when: ee_create_controller_def


### PR DESCRIPTION
Don't print the full EE definition when including tasks from 00_build_ee.yml