### PR TITLE
docs(readme): standardize links, fix LICENSE, add Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ It is not listed as a dependency because of issues with syncing the validated co
 
 |                                      Collection Name                                                  |                      Purpose                      |
 |:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
-| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                   | Ansible Automation Platform configuration |
-| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration) | Automation controller configuration       |
+| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                     | Ansible Automation Platform configuration         |
+| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration)   | Automation controller configuration               |
 | [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
 | [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                             | Ansible Automation Platform Utilities             |
 | [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)                | Configuration Template for this suite             |

--- a/README.md
+++ b/README.md
@@ -24,19 +24,24 @@ It is not listed as a dependency because of issues with syncing the validated co
 
 ## Links to Ansible Automation Platform Collections
 
-|                                      Collection Name                                         |                 Purpose                  |
-|:--------------------------------------------------------------------------------------------:|:----------------------------------------:|
-| [awx.awx/Ansible.controller repo](https://github.com/ansible/awx/tree/devel/awx_collection)  |   Automation controller modules          |
-|        [Ansible Hub Configuration](https://github.com/ansible/automation_hub_collection)     |       Automation hub configuration       |
+|                                      Collection Name                                |            Purpose            |
+|:-----------------------------------------------------------------------------------:|:-----------------------------:|
+| [ansible.platform repo](https://github.com/ansible/ansible.platform)                | gateway/platform modules      |
+| [ansible.hub repo](https://github.com/ansible-collections/ansible_hub)              | Automation hub modules        |
+| [ansible.controller repo](https://github.com/ansible/awx/tree/devel/awx_collection) | Automation controller modules |
+| [ansible.eda repo](https://github.com/ansible/event-driven-ansible)                 | Event Driven Ansible modules  |
 
 ## Links to other Validated Configuration Collections for Ansible Automation Platform
 
-|                                      Collection Name                                       |                 Purpose                  |
-|:------------------------------------------------------------------------------------------:|:----------------------------------------:|
-| [Controller Configuration](https://github.com/redhat-cop/controller_configuration)         |   Automation controller configuration    |
-|             [EE Utilities](https://github.com/redhat-cop/ee_utilities)                     | Execution Environment creation utilities |
-|     [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)              |  Ansible Automation Platform Utilities   |
-|   [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)   |  Configuration Template for this suite   |
+|                                      Collection Name                                                  |                      Purpose                      |
+|:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
+| [AAP >= 2.5 Configuration](https://github.com/redhat-cop/infra.aap_configuration)                   | Ansible Automation Platform configuration |
+| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration) | Automation controller configuration       |
+| [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
+| [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                             | Ansible Automation Platform Utilities             |
+| [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)                | Configuration Template for this suite             |
+| [Ansible Validated Gitlab Workflows](https://gitlab.com/redhat-cop/infra/ansible_validated_workflows) | Gitlab CI/CD Workflows for ansible content        |
+| [Ansible Validated GitHub Workflows](https://github.com/redhat-cop/infra.ansible_validated_workflows) | GitHub CI/CD Workflows for ansible content        |
 
 ## Included content
 
@@ -73,6 +78,8 @@ ansible-playbook infra.ee_utilities.create_execution_environment.yml
 
 ## Release and Upgrade Notes
 
+For details on changes between versions, please see [the changelog for this collection](https://github.com/redhat-cop/ee_utilities/blob/devel/CHANGELOG.rst).
+
 ## Releasing, Versioning and Deprecation
 
 This collection follows [Semantic Versioning](https://semver.org/). More details on versioning can be found [in the Ansible docs](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#collection-versions).
@@ -92,4 +99,8 @@ More information about contributing can be found in our [Contribution Guidelines
 
 GNU General Public License v3.0 or later.
 
-See [LICENCE](LICENSE) to see the full text.
+See [LICENSE](https://github.com/redhat-cop/ee_utilities/blob/devel/LICENSE) to see the full text.
+
+## Support
+
+This collection is [Ansible Validated Content](https://access.redhat.com/articles/3166901). It is reviewed and tested by Red Hat but is not supported under a Red Hat SLA. For reporting issues and requesting improvements, file an issue at the [EE Utilities repository](https://github.com/redhat-cop/ee_utilities/issues). Community help is also available on the [Ansible Forum](https://forum.ansible.com/tag/infra-config-as-code).

--- a/changelogs/fragments/certification-review-updates.yaml
+++ b/changelogs/fragments/certification-review-updates.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - README - Standardized collection links tables, added changelog link, fixed LICENSE link, and added Support section for certification review.


### PR DESCRIPTION
## Summary
- Standardize "Links to Ansible Automation Platform Collections" table with current repos
- Standardize "Links to other Validated Configuration Collections" table with all sibling collections
- Add changelog link in "Release and Upgrade Notes" section
- Fix `LICENCE` typo to `LICENSE` and convert to absolute GitHub URL
- Add Support section clarifying this is Ansible Validated Content

## Changes
- `README.md`: Updated both links tables, added changelog link, fixed LICENSE link, added Support section
- `changelogs/fragments/certification-review-updates.yaml`: Changelog fragment

## Test plan
- [ ] Pre-commit checks pass
- [ ] Changelog fragment added in `changelogs/fragments/`
- [ ] README renders correctly on GitHub


Made with [Cursor](https://cursor.com)