### PR TITLE
Deprecation of image tag vs tags in controller EE definition

### DIFF
--- a/changelogs/fragments/259-image-tag-deprecation.yaml
+++ b/changelogs/fragments/259-image-tag-deprecation.yaml
@@ -1,7 +1,7 @@
 ---
-minor_changes
-  - ee_builder role - linting fix - long line in Pull base image" task (https://github.com/redhat-cop/ee_utilities/pull/256)
+minor_changes:
+  - ee_builder role - linting fix - long line in Pull base image task (https://github.com/redhat-cop/ee_utilities/pull/256)
 bugfixes:
-  - ee_builder role - When creating Controller EE definition, use the first item in tags: entry of ee_list item. (https://github.com/redhat-cop/ee_utilities/issues/259)
+  - ee_builder role - When creating Controller EE definition, use the first item in tags entry of ee_list item. (https://github.com/redhat-cop/ee_utilities/issues/259)
 
 ...

--- a/changelogs/fragments/259-image-tag-deprecation.yaml
+++ b/changelogs/fragments/259-image-tag-deprecation.yaml
@@ -1,0 +1,7 @@
+---
+minor_changes
+  - ee_builder role - linting fix - long line in Pull base image" task (https://github.com/redhat-cop/ee_utilities/pull/256)
+bugfixes:
+  - ee_builder role - When creating Controller EE definition, use the first item in tags: entry of ee_list item. (https://github.com/redhat-cop/ee_utilities/issues/259)
+
+...

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -79,7 +79,7 @@ It takes variables from the following sections the list variables section.
 |:---:|:---:|:---:|:---:|
 |`name`||yes|Name of the ee image to create. Only the name goes here, the namespace goes in the ee_registry_dest variable|
 |`tag`||no|[DEPRECATED] Tag to use when pushing the image.|
-|`tags`||no|A list of tags to use when pushing the image.|
+|`tags`||no|A list of tags to use when pushing the image. If `ee_create_controller_def` is `true`, the first tag in the list will be used as the tag in the Controller EE definition. |
 |`dependencies`|dict|no|This section allows you to describe any dependencies that will need to be installed into the final image. Reference [builder dependencies documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#dependencies), examples and our examples for its structure.|
 |`build_steps`|dict|no|This section enables you to specify custom build commands for any build phase. Reference [builder build_steps documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#additional-build-steps), examples and our examples for its structure.|
 |`build_items`|list|no|This is a list of files or folders that will be copied to the working directory for use with the build files. Example below.|

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -61,7 +61,7 @@ Best practice is to use the default images, unless needing to pull from another 
 |`ee_pull_collections_from_hub`|true|no|bool|Whether or not to pull collections from a specific hub for use in building an Execution Environment. This will create entries that adds the ansible.cfg file into the EE. These can be hidden using environment variables as detailed [in this article](https://developers.redhat.com/articles/2025/01/23/strategies-eliminating-ansible-hardcoded-credentials)||
 |`ee_ah_host`|`aap_hostname`|no|str|Host to use for ansible config file. Alternative default is to use variable from infra.ah_configuration. (if AAP 2.5 use gateway host and infra.aap_configuration) Required if `ee_pull_collections_from_hub` is `True`.||
 |`ee_ah_token`|`aap_token`|no|str|Token to use for ansible config file. Alternative default is to use variable from infra.ah_configuration. Required if `ee_pull_collections_from_hub` is `True`.||
-|`ee_aap_version`|`2.4`|no|str|Changes what API endpoint to point to depending on AAP version||
+|`ee_aap_version`|`2.4`|no|float|Changes what API endpoint to point to depending on AAP version||
 |`ee_create_controller_def`|false|no|bool|Option to create the 'controller_execution_environments' definition for use by the infra.controller_configuration role||
 
 ### Execution environment list

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -79,7 +79,7 @@ It takes variables from the following sections the list variables section.
 |:---:|:---:|:---:|:---:|
 |`name`||yes|Name of the ee image to create. Only the name goes here, the namespace goes in the ee_registry_dest variable|
 |`tag`||no|[DEPRECATED] Tag to use when pushing the image.|
-|`tags`||no|A list of tags to use when pushing the image. If `ee_create_controller_def` is `true`, the first tag in the list will be used as the tag in the Controller EE definition. |
+|`tags`||no|A list of tags to use when pushing the image. If `ee_create_controller_def` is `true`, the first tag in the list will be used as the tag in the Controller EE definition.|
 |`dependencies`|dict|no|This section allows you to describe any dependencies that will need to be installed into the final image. Reference [builder dependencies documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#dependencies), examples and our examples for its structure.|
 |`build_steps`|dict|no|This section enables you to specify custom build commands for any build phase. Reference [builder build_steps documentation](https://ansible.readthedocs.io/projects/builder/en/stable/definition/#additional-build-steps), examples and our examples for its structure.|
 |`build_items`|list|no|This is a list of files or folders that will be copied to the working directory for use with the build files. Example below.|

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -16,7 +16,9 @@
 
 - name: Pull base image
   containers.podman.podman_image:
-    name: "{{ __execution_environment_definition.images.base_image.name | default(__execution_environment_definition.images.base_image) | default(__execution_environment_definition.base_image) | default(ee_base_image) }}"
+    name: "{{ __execution_environment_definition.images.base_image.name |
+      default(__execution_environment_definition.images.base_image) |
+      default(__execution_environment_definition.base_image) | default(ee_base_image) }}"
     username: "{{ ee_base_registry_username | default(omit, true) }}"
     password: "{{ ee_base_registry_password | default(omit, true) }}"
     validate_certs: "{{ ee_validate_certs | default(omit) }}"

--- a/roles/ee_builder/templates/ee_controller.yaml.j2
+++ b/roles/ee_builder/templates/ee_controller.yaml.j2
@@ -2,7 +2,7 @@
 controller_execution_environments:
 {% for exec_env in ee_list %}
 - name: {{ exec_env.alt_name | default(exec_env.name)}}
-  image: {{ ee_registry_dest }}/{{ exec_env.name }}{% if exec_env.tag is defined %}:{{ exec_env.tag }}{% endif %}
+  image: {{ ee_registry_dest }}/{{ exec_env.name }}{% if exec_env.tags is defined and exec_env.tags is list and (exec_env.tags | count) > 0 %}:{{ exec_env.tags[0] }}{% elif exec_env.tag is defined %}:{{ exec_env.tag }}{% endif %}
 
 {% if exec_env.description is defined %}
   description: {{ exec_env.description }}

--- a/roles/ee_builder/templates/ee_controller.yaml.j2
+++ b/roles/ee_builder/templates/ee_controller.yaml.j2
@@ -2,7 +2,7 @@
 controller_execution_environments:
 {% for exec_env in ee_list %}
 - name: {{ exec_env.alt_name | default(exec_env.name)}}
-  image: {{ ee_registry_dest }}/{{ exec_env.name }}{% if exec_env.tags is defined and exec_env.tags is list and (exec_env.tags | count) > 0 %}:{{ exec_env.tags[0] }}{% elif exec_env.tag is defined %}:{{ exec_env.tag }}{% endif %}
+  image: {{ ee_registry_dest }}/{{ exec_env.name }}{% if exec_env.tags is defined and exec_env.tags is iterable and (exec_env.tags is not string and exec_env.tags is not mapping) and (exec_env.tags | count) > 0 %}:{{ exec_env.tags[0] }}{% elif exec_env.tag is defined %}:{{ exec_env.tag }}{% endif %}
 
 {% if exec_env.description is defined %}
   description: {{ exec_env.description }}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

With the deprecation of `tag` in the EE definition, anybody using only `tags` will find that the controller EE definition doesn't have a tag specified. This PR arbitrarily chooses the first tag in the `tags` list to push to the Controller EE definition. The `tags` list will take precedence over `tag` if both are defined.

It also fixes one ansible-lint complaint, that of a long line in the *Pull base image* task in `roles/ee_builder/tasks/00_build_ee.yml`.

Finally, the README was updated to incorporate the `tag` vs `tags` update, and also to list `ee_aap_version` as type `float` rather than `str`, as anybody formatting it as a string (i.e. in quotes) will get an error of a type mismatch on comparison of the string (AnsibleUnicode) to a float, at least with recent versions of ansible-core.

# How should this be tested?

Create two definitions: one using the (deprecated) `tag` and the other using the new `tags` list. Build both and push both to Controller by calling `infra.ee_utilities.ee_builder` and then `infra.aap_configuration.controller_execution_environments` in the same play. Both images should appear with the tag specified in Controller.

Previously, an image built using only `tags` would not have a tag specified in the Controller EE definition.

# Is there a relevant Issue open for this?

[Yes](https://github.com/redhat-cop/ee_utilities/issues/259)

# Other Relevant info, PRs, etc

This is just a suggestion, and I've arbitrarily chosen the first item in the `tags` list as the tag to use in Controller. Please feel free to discard this and create a better solution. I'm not the best at this, but it does at least pass ansible-lint.
