### PR TITLE
Make it possible to create build files only

### DIFF
--- a/changelogs/fragments/use-hub-token.yml
+++ b/changelogs/fragments/use-hub-token.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - allow for creating build files only without building images
+...

--- a/roles/ee_builder/README.md
+++ b/roles/ee_builder/README.md
@@ -63,6 +63,7 @@ Best practice is to use the default images, unless needing to pull from another 
 |`ee_ah_token`|`aap_token`|no|str|Token to use for ansible config file. Alternative default is to use variable from infra.ah_configuration. Required if `ee_pull_collections_from_hub` is `True`.||
 |`ee_aap_version`|`2.4`|no|float|Changes what API endpoint to point to depending on AAP version||
 |`ee_create_controller_def`|false|no|bool|Option to create the 'controller_execution_environments' definition for use by the infra.controller_configuration role||
+|`ee_build_files_only`|false|no|bool|Whether to create build files only and skip building images.||
 
 ### Execution environment list
 

--- a/roles/ee_builder/defaults/main.yml
+++ b/roles/ee_builder/defaults/main.yml
@@ -28,6 +28,7 @@ ee_builder_dir_clean: true
 ee_validate_certs: false
 ee_prune_images: true
 ee_create_controller_def: false
+ee_build_files_only: false
 
 # Registry
 # name

--- a/roles/ee_builder/tasks/00_build_ee.yml
+++ b/roles/ee_builder/tasks/00_build_ee.yml
@@ -14,16 +14,16 @@
   register: build_dir
   when: ee_builder_dir is not defined
 
-- name: Pull base image
-  containers.podman.podman_image:
-    name: "{{ __execution_environment_definition.images.base_image.name |
-      default(__execution_environment_definition.images.base_image) |
-      default(__execution_environment_definition.base_image) | default(ee_base_image) }}"
-    username: "{{ ee_base_registry_username | default(omit, true) }}"
-    password: "{{ ee_base_registry_password | default(omit, true) }}"
-    validate_certs: "{{ ee_validate_certs | default(omit) }}"
-    force: true
-  when: ee_update_base_images
+- name: Create EE definition file
+  vars:
+    yaml_prefix: >-
+      {{ '' if not ee_build_files_only else
+         __execution_environment_definition.name.replace('/', '-') + '-' }}
+  ansible.builtin.template:
+    src: execution-environment.yaml.j2
+    dest: "{{ ee_builder_dir | default(build_dir.path) }}/{{ yaml_prefix }}execution-environment.yaml"
+    mode: "0644"
+  when: not __execution_environment_definition.skip_generation | default(false) | bool
 
 - name: Copy needed files/directories for additional_build_files
   ansible.builtin.copy:
@@ -42,12 +42,18 @@
     mode: "0644"
   when: ee_pull_collections_from_hub
 
-- name: Create EE definition file
-  ansible.builtin.template:
-    src: execution-environment.yaml.j2
-    dest: "{{ ee_builder_dir | default(build_dir.path) }}/execution-environment.yaml"
-    mode: "0644"
-  when: not __execution_environment_definition.skip_generation | default(false) | bool
+- name: Pull base image
+  containers.podman.podman_image:
+    name: "{{ __execution_environment_definition.images.base_image.name |
+      default(__execution_environment_definition.images.base_image) |
+      default(__execution_environment_definition.base_image) | default(ee_base_image) }}"
+    username: "{{ ee_base_registry_username | default(omit, true) }}"
+    password: "{{ ee_base_registry_password | default(omit, true) }}"
+    validate_certs: "{{ ee_validate_certs | default(omit) }}"
+    force: true
+  when:
+    - ee_update_base_images
+    - not ee_build_files_only
 
 - name: Run the Ansible Builder program
   ansible.builtin.command: >
@@ -89,6 +95,7 @@
   args:
     chdir: "{{ ee_builder_dir | default(build_dir.path) }}/"
   changed_when: true  # these will always run and will always report "changed" otherwise
+  when: not ee_build_files_only
 
 - name: Push image to registry
   containers.podman.podman_image:
@@ -113,7 +120,9 @@
     }}
   loop_control:
     loop_var: __execution_environment_tag
-  when: ee_image_push
+  when:
+    - ee_image_push
+    - not ee_build_files_only
 
 - name: Remove build directory
   ansible.builtin.file:

--- a/roles/ee_builder/tasks/main.yml
+++ b/roles/ee_builder/tasks/main.yml
@@ -7,7 +7,9 @@
     label: "{{ __execution_environment_definition.name }}"
 
 - name: Push to controller
-  when: ee_create_controller_def
+  when:
+    - ee_create_controller_def
+    - not ee_build_files_only
   delegate_to: localhost
   block:
     - name: Create temporary directory


### PR DESCRIPTION
This change makes it possible to use the EE vars files with the ee_builder role or just generate build files for later use, for example with the AAP ansible-builder image + docker/podman.

Resolves #276